### PR TITLE
Fixes #13 automatic schema inference

### DIFF
--- a/yummy-rs/yummy-mlflow/src/main.rs
+++ b/yummy-rs/yummy-mlflow/src/main.rs
@@ -3,12 +3,16 @@
 async fn main()  -> std::io::Result<()> {
 
     //let mlmodel_path = "../tests/mlflow/catboost_model/my_model".to_string();
-    let mlmodel_path = "../tests/mlflow/lightgbm_model/lightgbm_my_model".to_string();
+    //let mlmodel_path = "../tests/mlflow/lightgbm_model/lightgbm_my_model".to_string();
 
+    /* 
     yummy_mlflow::serve_mlflow_model(
         mlmodel_path,
         "0.0.0.0".to_string(),
         8080,
         "Debug".to_string(),
     ).await
+    */
+
+    Ok(())
 }

--- a/yummy/sources/delta.py
+++ b/yummy/sources/delta.py
@@ -132,10 +132,6 @@ class DeltaSource(YummyDataSource):
         # TODO: validate a DeltaSource
         pass
 
-    @staticmethod
-    def source_datatype_to_feast_value_type() -> Callable[[str], ValueType]:
-        return type_map.pa_to_feast_value_type
-
 
 class DeltaSourceReader(YummyDataSourceReader):
 

--- a/yummy/sources/file.py
+++ b/yummy/sources/file.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from typing import Callable, Dict, List, Optional, Union, Any
+from typing import Callable, Dict, List, Optional, Union, Any, Iterable, Tuple
 
 from feast import type_map
 from feast.data_source import DataSource
@@ -10,7 +10,7 @@ from feast.value_type import ValueType
 import pandas as pd
 import pyarrow
 from yummy.sources.source import YummyDataSource
-from yummy.backends.backend import Backend, BackendType, YummyDataSourceReader
+from yummy.backends.backend import Backend, BackendType, YummyDataSourceReader, BackendFactory
 
 
 class YummyFileDataSource(YummyDataSource):
@@ -99,10 +99,6 @@ class YummyFileDataSource(YummyDataSource):
     def validate(self, config: RepoConfig):
         # TODO: validate a FileSource
         pass
-
-    @staticmethod
-    def source_datatype_to_feast_value_type() -> Callable[[str], ValueType]:
-        return type_map.pa_to_feast_value_type
 
 
 class ParquetSource(YummyFileDataSource):
@@ -365,7 +361,4 @@ class CsvSourceReader(ParquetSourceReader):
                 has_header=data_source.header,
                 delimiter=data_source.delimiter,
             )
-
-
-
 

--- a/yummy/sources/iceberg.py
+++ b/yummy/sources/iceberg.py
@@ -132,10 +132,6 @@ class IcebergSource(YummyDataSource):
         # TODO: validate a DeltaSource
         pass
 
-    @staticmethod
-    def source_datatype_to_feast_value_type() -> Callable[[str], ValueType]:
-        return type_map.pa_to_feast_value_type
-
 
 class IcebergSourceReader(YummyDataSourceReader):
 


### PR DESCRIPTION
This commit fixes automatic schema inference. 
Important note for spark and csv data source is that spark will assign all types to `string` thus it is better to provide schema manually. 